### PR TITLE
fix: restore monkey patch on start() failure to prevent cascade failures

### DIFF
--- a/src/queryRunnerWrapper.ts
+++ b/src/queryRunnerWrapper.ts
@@ -8,16 +8,14 @@ interface QueryRunnerWrapper extends QueryRunner {
   releaseQueryRunner(): Promise<void>;
 }
 
-let release: () => Promise<void>;
-
 const wrap = (originalQueryRunner: QueryRunner): QueryRunnerWrapper => {
-  release = originalQueryRunner.release;
+  const originalRelease = originalQueryRunner.release.bind(originalQueryRunner);
   originalQueryRunner.release = () => {
     return Promise.resolve();
   };
 
   (originalQueryRunner as QueryRunnerWrapper).releaseQueryRunner = () => {
-    originalQueryRunner.release = release;
+    originalQueryRunner.release = originalRelease;
     return originalQueryRunner.release();
   };
 

--- a/src/transactionalTestContext.ts
+++ b/src/transactionalTestContext.ts
@@ -18,6 +18,7 @@ export default class TransactionalTestContext {
       await this.queryRunner.connect();
       await this.queryRunner.startTransaction();
     } catch (error) {
+      this.restoreQueryRunnerCreation();
       await this.cleanUpResources();
       throw error;
     }
@@ -25,12 +26,13 @@ export default class TransactionalTestContext {
 
   async finish(): Promise<void> {
     if (!this.queryRunner) {
+      this.restoreQueryRunnerCreation();
       throw new Error('Context not started. You must call "start" before finishing it.');
     }
     try {
       await this.queryRunner.rollbackTransaction();
-      this.restoreQueryRunnerCreation();
     } finally {
+      this.restoreQueryRunnerCreation();
       await this.cleanUpResources();
     }
   }
@@ -41,12 +43,12 @@ export default class TransactionalTestContext {
   }
 
   private monkeyPatchQueryRunnerCreation(queryRunner: QueryRunnerWrapper): void {
-    this.originQueryRunnerFunction = this.connection.createQueryRunner
-    this.connection.createQueryRunner = () => queryRunner
+    this.originQueryRunnerFunction = this.connection.createQueryRunner;
+    this.connection.createQueryRunner = () => queryRunner;
   }
 
   private restoreQueryRunnerCreation(): void {
-    this.connection.createQueryRunner = this.originQueryRunnerFunction
+    this.connection.createQueryRunner = this.originQueryRunnerFunction;
   }
 
   private async cleanUpResources(): Promise<void> {


### PR DESCRIPTION
## Problem

When `start()` fails (e.g., due to a database connection timeout), `cleanUpResources()` releases the query runner and sets `this.queryRunner = null`, but **never restores the monkey-patched `createQueryRunner`** on the DataSource.

This causes a cascade failure:

1. `start()` fails → query runner released, but `createQueryRunner` still returns the stale wrapper
2. `finish()` sees `queryRunner === null` → throws "Context not started" **without restoring** `createQueryRunner`
3. Next test creates a new `TransactionalTestContext` → `buildWrappedQueryRunner()` calls the still-patched `createQueryRunner()` → receives the old, released query runner
4. `connect()` on the released runner → `QueryRunnerAlreadyReleasedError`
5. **Every remaining test in the file fails identically**

In CI environments with connection pressure, this turns a single transient connection failure into a full test suite wipeout.

## Fix

### `transactionalTestContext.ts`
- **`start()`**: Call `restoreQueryRunnerCreation()` in the catch block before `cleanUpResources()`
- **`finish()`**: Call `restoreQueryRunnerCreation()` even when `queryRunner` is null, and move it to the `finally` block so it always executes regardless of rollback success

### `queryRunnerWrapper.ts`
- Use a **closure-scoped** `originalRelease` variable instead of the module-level `let release`. The module-level variable could be overwritten if `wrap()` is called multiple times, causing cross-context pollution.

## Tests

All existing tests pass with 100% coverage.